### PR TITLE
Disable m2 local repository by default

### DIFF
--- a/amm/runtime/src/main/scala/ammonite/runtime/tools/DependencyThing.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/tools/DependencyThing.scala
@@ -163,12 +163,6 @@ object Resolvers {
      "/[organisation]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]",
      m2 = false
    ),
-   Resolver.File(
-     "m2",
-     "/.m2/repository",
-     "/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]",
-     m2 = true
-   ),
    Resolver.Http(
      "central",
      "https://repo1.maven.org/maven2/",


### PR DESCRIPTION
It often contains partial stuff (like only the metadata for some dependencies), which confuse coursier (that assumes that if a repo has the metadata, it must have the jars too, hence not found errors)